### PR TITLE
Additional api methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var events = require('events');
 var util = require('util');
 
-var VirtualSerialPort = function(path, options){
+var VirtualSerialPort = function(path, options, openImmediately, callback) {
 	events.EventEmitter.call(this);
 
 	var self = this;
@@ -11,13 +11,22 @@ var VirtualSerialPort = function(path, options){
 		self.emit("data", data);
 	};
 
-	setTimeout(function(){
-		open = true;
-		self.emit("open");
-	}, 100);
+    if (openImmediately || openImmediately === undefined || openImmediately === null) {
+        process.nextTick(function() {
+            self.open(callback);
+        });
+    }
 };
 
 util.inherits(VirtualSerialPort, events.EventEmitter);
+
+VirtualSerialPort.prototype.open = function open(callback) {
+    this.open = true;
+    this.emit('open');
+    if (callback) {
+        callback();
+    }
+};
 
 VirtualSerialPort.prototype.write = function write(buffer, callback) {
     if (this.open) this.emit("dataToDevice", buffer);

--- a/index.js
+++ b/index.js
@@ -32,7 +32,9 @@ VirtualSerialPort.prototype.write = function write(buffer, callback) {
     if (this.open) this.emit("dataToDevice", buffer);
     // This callback should receive both an error and result, however result is
     // undocumented so I do not know what it should contain
-    callback();
+    if (callback) {
+        callback();
+    }
 };
 
 VirtualSerialPort.prototype.pause = function pause() {
@@ -42,16 +44,22 @@ VirtualSerialPort.prototype.resume = function resume() {
 };
 
 VirtualSerialPort.prototype.flush = function flush(callback) {
-    callback();
+    if (callback) {
+        callback();
+    }
 };
 
 VirtualSerialPort.prototype.drain = function drain(callback) {
-    callback();
+    if (callback) {
+        callback();
+    }
 };
 
 VirtualSerialPort.prototype.close = function close(callback) {
     this.removeAllListeners();
-    callback();
+    if (callback) {
+        callback();
+    }
 };
 
 module.exports = VirtualSerialPort;

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ var VirtualSerialPort = function(path, options){
 		open = true;
 		self.emit("open");
 	}, 100);
-}
+};
+
 util.inherits(VirtualSerialPort, events.EventEmitter);
 
 module.exports = VirtualSerialPort;

--- a/index.js
+++ b/index.js
@@ -7,11 +7,6 @@ var VirtualSerialPort = function(path, options){
 	var self = this;
 	var open = false;
 
-
-	this.write = function(data) {
-		if (open) self.emit("dataToDevice", data);
-	};
-
 	this.writeToComputer = function(data) {
 		self.emit("data", data);
 	};
@@ -23,5 +18,9 @@ var VirtualSerialPort = function(path, options){
 };
 
 util.inherits(VirtualSerialPort, events.EventEmitter);
+
+VirtualSerialPort.prototype.write = function write(buffer, callback) {
+    if (this.open) this.emit("dataToDevice", buffer);
+};
 
 module.exports = VirtualSerialPort;

--- a/index.js
+++ b/index.js
@@ -30,6 +30,28 @@ VirtualSerialPort.prototype.open = function open(callback) {
 
 VirtualSerialPort.prototype.write = function write(buffer, callback) {
     if (this.open) this.emit("dataToDevice", buffer);
+    // This callback should receive both an error and result, however result is
+    // undocumented so I do not know what it should contain
+    callback();
+};
+
+VirtualSerialPort.prototype.pause = function pause() {
+};
+
+VirtualSerialPort.prototype.resume = function resume() {
+};
+
+VirtualSerialPort.prototype.flush = function flush(callback) {
+    callback();
+};
+
+VirtualSerialPort.prototype.drain = function drain(callback) {
+    callback();
+};
+
+VirtualSerialPort.prototype.close = function close(callback) {
+    this.removeAllListeners();
+    callback();
 };
 
 module.exports = VirtualSerialPort;


### PR DESCRIPTION
This pull-request is based upon the code from Sean.

It includes changes to how the open behaves to better mimic node-serialport. It also adds some more methods such as:
- pause
- resume
- flush
- drain
- close
