### PR TITLE
Added the parsers object to the virtual serial port.

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,16 @@ VirtualSerialPort.prototype.close = function close(callback) {
     }
 };
 
-VirtualSerialPort.parsers = SerialPort.parsers;
+
+
+if (SerialPort.SerialPort) {
+    // for v2.x serialport API 
+    VirtualSerialPort = { 
+        SerialPort: VirtualSerialPort, 
+        parsers : SerialPort.parsers
+    };
+} else {
+    VirtualSerialPort.parsers = SerialPort.parsers;
+}
 
 module.exports = VirtualSerialPort;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
-var events     = require('events');
-var util       = require('util');
-var SerialPort = require('serialport');
+var events = require('events');
+var util = require('util');
 
 var VirtualSerialPort = function(path, options, openImmediately, callback) {
     events.EventEmitter.call(this);
@@ -69,15 +68,22 @@ VirtualSerialPort.prototype.close = function close(callback) {
 };
 
 
-
-if (SerialPort.SerialPort) {
-    // for v2.x serialport API 
-    VirtualSerialPort = { 
-        SerialPort: VirtualSerialPort, 
-        parsers : SerialPort.parsers
-    };
-} else {
-    VirtualSerialPort.parsers = SerialPort.parsers;
+try {
+    var SerialPort = require('serialport');
+    if (SerialPort.SerialPort) {
+        // for v2.x serialport API 
+        VirtualSerialPort = {
+            SerialPort: VirtualSerialPort,
+            parsers: SerialPort.parsers
+        };
+    } else {
+        VirtualSerialPort.parsers = SerialPort.parsers;
+    }
 }
+catch(error) {
+    console.warn('VirtualSerialPort - NO parsers available');
+}
+
+
 
 module.exports = VirtualSerialPort;

--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@ VirtualSerialPort.prototype.close = function close(callback) {
     }
 };
 
+VirtualSerialPort.prototype.isOpen = function isOpen() {
+    return this.open ? true : false;
+};
 
 try {
     var SerialPort = require('serialport');

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-var events = require('events');
-var util   = require('util');
+var events     = require('events');
+var util       = require('util');
+var SerialPort = require('serialport');
 
 var VirtualSerialPort = function(path, options, openImmediately, callback) {
     events.EventEmitter.call(this);
@@ -66,5 +67,7 @@ VirtualSerialPort.prototype.close = function close(callback) {
         callback();
     }
 };
+
+VirtualSerialPort.parsers = SerialPort.parsers;
 
 module.exports = VirtualSerialPort;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "url": "https://github.com/reyiyo/virtual-serialport/issues"
   },
   "dependencies": {
-    "serialport": "^4.0.3"
+    "serialport": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/reyiyo/virtual-serialport/issues"
+  },
+  "dependencies": {
+    "serialport": "^4.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "bugs": {
     "url": "https://github.com/reyiyo/virtual-serialport/issues"
   },
-  "dependencies": {
+  "optionalDependencies": {
     "serialport": "*"
   }
 }


### PR DESCRIPTION
Pretty simple, just copied the parsers property from the real SerialPort to the VirtualSerialPort. The parsers don't actually do anything - but they do let you use the virtual serial port if your code expects SerialPort.parsers to be present.
