### PR TITLE
Align VirtualSerialPort arguments with SerialPort

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,17 +3,19 @@
 var events = require('events');
 var util = require('util');
 
-var VirtualSerialPort = function(path, options, openImmediately, callback) {
+var VirtualSerialPort = function(path, options, callback) {
     events.EventEmitter.call(this);
 
     var self = this;
+
+    this.options = options;
 
     this.opened = false;
     this.writeToComputer = function(data) {
         self.emit('data', data);
     };
 
-    if(openImmediately || typeof openImmediately === 'undefined' || openImmediately === null) {
+    if(options.autoOpen !== false) {
         process.nextTick(function() {
             self.open(callback);
         });
@@ -24,6 +26,7 @@ util.inherits(VirtualSerialPort, events.EventEmitter);
 
 VirtualSerialPort.prototype.open = function open(callback) {
     this.opened = true;
+
     process.nextTick(function() {
         this.emit('open');
     }.bind(this));

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,8 @@
 var VirtualSerialPort = require('../');
 
-var sp = new VirtualSerialPort('/dev/null');
+var sp = new VirtualSerialPort('/dev/null', {
+  autoOpen: false
+});
 
 // Simple echo function for fake Arduino
 sp.on('dataToDevice', function(data) {
@@ -18,4 +20,8 @@ sp.on('open', function() {
     sp.on("data", function(data) {
         console.log("Computer: " + (data == 1 ? "BLEEP" : "BLOOP"));
     });
+});
+
+sp.open(function() {
+  console.log("Open callback!");
 });


### PR DESCRIPTION
`openImmediately` isn't an argument for `SerialPort`. This commit drops
that argument and replaces with the correct `options.autoOpen`

---------------

More additions to make `virtual-serialport` more consistent with `serialport`