### PR TITLE
Throw error message if SerialPort is already open

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,23 @@ var VirtualSerialPort = function(path, options, callback) {
 
 util.inherits(VirtualSerialPort, events.EventEmitter);
 
+VirtualSerialPort.prototype._error = function(error, callback) {
+    if (callback) {
+        callback.call(this, error);
+    } else {
+        this.emit('error', error);
+    }
+};
+
+VirtualSerialPort.prototype._asyncError = function(error, callback) {
+    process.nextTick(function() { this._error(error, callback); }.bind(this));
+};
+
 VirtualSerialPort.prototype.open = function open(callback) {
+    if (this.opened) {
+        return this._asyncError(new Error('Port is already open'));
+    }
+    
     this.opened = true;
 
     process.nextTick(

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,16 @@ sp.on('open', function() {
     });
 });
 
+sp.on('error', function(err) {
+    if(err.message === 'Port is already open') {
+      console.log('Got expected error')
+    }
+});
+
 sp.open(function() {
     console.log('Open callback!');
+});
+
+sp.open(function() {
+    console.log('Open callback #2 - should\'ve never been called!');
 });


### PR DESCRIPTION
Virtual SerialPort keeps track of its status, but it's not being acted upon.