### PR TITLE
Better sync with node-serialport

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,23 +74,21 @@ sp.write("BLOOP!"); // "Arduino says, BLOOP!"
 Simulates the port opening. It returns the callback execution and emits the `open` event on
 `process.nextTick()`
 
-Writes data to the virtual device. Equivalent to `sp.emit("dataToDevice", data)`.
-
 #### sp.write(data)
 Writes data to the virtual device. Equivalent to `sp.emit("dataToDevice", data)`.
 
-#### sp.isOpen()
+#### sp.isOpen() OR sp.isOpen (both supported)
 Returns boolean indicating wether the port is open or not. It returns the value of `sp.open` which
 you may set manually.
 
 #### sp.pause()
-This method is for API compatibility. It actually does nothing here.
+Sets internal Pause status and make sure all data send by "writeToComputer" is stored for later delivery
 
 #### sp.resume()
-This method is for API compatibility. It actually does nothing here.
+Release internal Pause status and send out all data that was stored during pause.
 
 #### sp.flush(callback)
-This method is for API compatibility. It actually does nothing and returns the callback call.
+Cleans all stored data that may be stored during pause
 
 #### sp.drain(callback)
 This method is for API compatibility. It actually does nothing and returns the callback call.
@@ -111,6 +109,7 @@ Act on data sent to the computer, as you would with an actual `SerialPort` insta
 #### sp.writeToComputer(data);
 
 Writes data to computer. Equivalent to `sp.emit("data", data)`
+Outputs warning and do not write the if port was not opened before.
 
 #### sp.on("dataToDevice", function(data) { ... })
 Act on data sent to the device.

--- a/index.js
+++ b/index.js
@@ -145,17 +145,18 @@ VirtualSerialPort.prototype.isOpen = function isOpen() {
 
 function VirtualSerialPortFactory() {
     try {
-        var SerialPort = require('serialport');
-        if (SerialPort.SerialPort) SerialPort = SerialPort.SerialPort;
+        var { SerialPort } = require('serialport');
         VirtualSerialPort.parsers = SerialPort.parsers;
-        
-        return VirtualSerialPort;
+
+        return {
+            SerialPort: VirtualSerialPort
+        }
     } catch (error) {
         console.warn('VirtualSerialPort - NO parsers available');
     }
 
     return {
-        Serialport: VirtualSerialPort
+        SerialPort: VirtualSerialPort
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -146,13 +146,17 @@ VirtualSerialPort.prototype.isOpen = function isOpen() {
 function VirtualSerialPortFactory() {
     try {
         var SerialPort = require('serialport');
+        if (SerialPort.SerialPort) SerialPort = SerialPort.SerialPort;
         VirtualSerialPort.parsers = SerialPort.parsers;
+        
         return VirtualSerialPort;
     } catch (error) {
         console.warn('VirtualSerialPort - NO parsers available');
     }
 
-    return VirtualSerialPort;
+    return {
+        Serialport: VirtualSerialPort
+    }
 }
 
 module.exports = new VirtualSerialPortFactory();

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 var events = require('events');
 var util = require('util');
 
-var VirtualSerialPort = function(path, options, callback) {
+var VirtualSerialPort = function(options, callback) {
     events.EventEmitter.call(this);
 
     var self = this;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virtual-serialport",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "A drop-in virtual replacement for node-serialport's SerialPort object",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
- support isOpen as property additional to the method
- add pause, resume and flush support
- do not emit data when port is not opened, but output warning
- update README
- prepare as 4.1.0? :-)