### PR TITLE
Add support for readable event

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Writes data to the virtual device. Equivalent to `sp.emit("dataToDevice", data)`
 #### sp.write(data)
 Writes data to the virtual device. Equivalent to `sp.emit("dataToDevice", data)`.
 
+#### sp.read()
+Reads data from the virtual device. (The last data written by  `sp.writeToComputer(data)`).
+
 #### sp.isOpen()
 Returns boolean indicating wether the port is open or not. It returns the value of `sp.open` which
 you may set manually.
@@ -106,11 +109,15 @@ Runs function once `SerialPort` is ready, as you would with an actual `SerialPor
 
 Act on data sent to the computer, as you would with an actual `SerialPort` instance.
 
+#### sp.on("readable", function() { ... })
+
+Act on when readable data ready to be read by the computer, as you would with an actual `SerialPort` instance.
+
 ### Non node-serialport methods/events:
 
 #### sp.writeToComputer(data);
 
-Writes data to computer. Equivalent to `sp.emit("data", data)`
+Writes data to computer. Equivalent to `sp.emit("data", data) and sp.emit("readable")` Also set data next read by sp.read()
 
 #### sp.on("dataToDevice", function(data) { ... })
 Act on data sent to the device.

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 var events = require('events');
 var util = require('util');
 
+let dataToRead = null;
+
 var VirtualSerialPort = function(path, options, callback) {
     events.EventEmitter.call(this);
 
@@ -13,6 +15,8 @@ var VirtualSerialPort = function(path, options, callback) {
     this.opened = false;
     this.writeToComputer = function(data) {
         self.emit('data', data);
+        dataToRead = data;
+        self.emit('readable');
     };
 
     if (options && options.autoOpen !== false) {
@@ -67,6 +71,10 @@ VirtualSerialPort.prototype.write = function write(buffer, callback) {
     if (callback) {
         return callback();
     }
+};
+
+VirtualSerialPort.prototype.read = function read() {
+    return dataToRead;
 };
 
 VirtualSerialPort.prototype.pause = function pause() {};

--- a/package.json
+++ b/package.json
@@ -1,14 +1,8 @@
 {
   "name": "virtual-serialport",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "A drop-in virtual replacement for node-serialport's SerialPort object",
   "main": "index.js",
-  "directories": {
-    "test": "test"
-  },
-  "scripts": {
-    "test": "node test/test.js"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/reyiyo/virtual-serialport"
@@ -54,6 +48,10 @@
     {
       "name": "Maxim Rubis",
       "url": "http://rub.is"
+    },
+    {
+      "name": "Mike Strong",
+      "email": "mike.strong@te.com"
     }
   ],
   "license": "MIT",
@@ -61,7 +59,7 @@
     "url": "https://github.com/reyiyo/virtual-serialport/issues"
   },
   "optionalDependencies": {
-    "serialport": "5.0.0",
-    "semver": "^5.3.0"
+    "serialport": "6.2.1",
+    "semver": "^5.6.0"
   }
 }


### PR DESCRIPTION
I have added support for the "readable" event and bumped the versions of the the dependencies in the package file.  I required the readable event for a test harness I'm working on.  Thanks.